### PR TITLE
Adds main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@dwayneparton/geojson-to-gpx",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Converts GeoJson to GPX",
+    "main": "dist/index.js",
     "browser": "dist/index.js",
     "module": "dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
This library is designed specifically for the browser. It should be bundled and used only there. How it works in node may be unpredictable as it uses browser specific features to work.