### PR TITLE
Web worker support

### DIFF
--- a/.changeset/nervous-suits-hide.md
+++ b/.changeset/nervous-suits-hide.md
@@ -1,0 +1,5 @@
+---
+"@dwayneparton/geojson-to-gpx": minor
+---
+
+Web Workers don't have access to document, this allows the passing of the implementation when you use library in worker. Thanks @bokolob

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -3,7 +3,7 @@
 
 name: Validate Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   validate:

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,9 +54,9 @@ export declare interface Options{
  * @returns XMLDocument
  * @see http://www.topografix.com/GPX/1/1/
  */
-export default function GeoJsonToGpx(geoJson: Feature | FeatureCollection, options?: Options): XMLDocument {
+export default function GeoJsonToGpx(geoJson: Feature | FeatureCollection, options?: Options, implementation: DOMImplementation=document.implementation): XMLDocument {
   // Create root XMLDocument
-  const doc = document.implementation.createDocument('http://www.topografix.com/GPX/1/1', '');
+  const doc = implementation.createDocument('http://www.topografix.com/GPX/1/1', '');
   const instruct = doc.createProcessingInstruction('xml', 'version="1.0" encoding="UTF-8"');
   doc.appendChild(instruct);
 


### PR DESCRIPTION
Workers don't have access to document. Also you don't have  a 'global' object.

This tiny patch should help with pass implementation when you  use library in worker.